### PR TITLE
Add package_path_map to config

### DIFF
--- a/lib/goon_model_gen/builder/abstract_builder.rb
+++ b/lib/goon_model_gen/builder/abstract_builder.rb
@@ -1,15 +1,19 @@
 require "goon_model_gen"
 
+require "goon_model_gen/config"
 require "goon_model_gen/golang/packages"
 
 module GoonModelGen
   module Builder
     class AbstractBuilder
+      attr_reader :config
       attr_reader :base_package_path
       attr_accessor :package_suffix
 
+      # @param config [GoonModelGen::Config]
       # @param base_package_path [String]
-      def initialize(base_package_path)
+      def initialize(config, base_package_path)
+        @config = config
         @base_package_path = base_package_path
       end
 

--- a/lib/goon_model_gen/builder/converter_builder.rb
+++ b/lib/goon_model_gen/builder/converter_builder.rb
@@ -1,5 +1,6 @@
 require "goon_model_gen"
 
+require "goon_model_gen/config"
 require "goon_model_gen/builder/abstract_builder"
 
 require "goon_model_gen/source/struct"
@@ -14,11 +15,11 @@ module GoonModelGen
       attr_reader :loader
       attr_reader :packages
 
-      # @param base_package_path [String]
+      # @param config [GoonModelGen::Config]
       # @param loader [Converter::Loader]
       # @param packages [Golang::Packages]
-      def initialize(base_package_path, loader, packages)
-        super(base_package_path)
+      def initialize(config, loader, packages)
+        super(config, config.converter_package_path)
         @package_suffix = "_conv"
         @loader = loader
         @packages = packages
@@ -70,7 +71,7 @@ module GoonModelGen
 
       # @param pkgs [Golang::Packages]
       def resolve_type_names(pkgs)
-        pkgs.resolve_type_names(Golang::DatastorePackageFactory.new.packages.dup.add(packages))
+        pkgs.resolve_type_names(Golang::DatastorePackageFactory.new(config.package_alias_map).packages.dup.add(packages))
       end
 
     end

--- a/lib/goon_model_gen/builder/converter_builder.rb
+++ b/lib/goon_model_gen/builder/converter_builder.rb
@@ -5,7 +5,7 @@ require "goon_model_gen/builder/abstract_builder"
 require "goon_model_gen/source/struct"
 
 require "goon_model_gen/golang/package"
-require "goon_model_gen/golang/datastore_supported"
+require "goon_model_gen/golang/datastore_package_factory"
 
 
 module GoonModelGen
@@ -70,7 +70,7 @@ module GoonModelGen
 
       # @param pkgs [Golang::Packages]
       def resolve_type_names(pkgs)
-        pkgs.resolve_type_names(Golang::DatastoreSupported.packages.dup.add(packages))
+        pkgs.resolve_type_names(Golang::DatastorePackageFactory.new.packages.dup.add(packages))
       end
 
     end

--- a/lib/goon_model_gen/builder/model_builder.rb
+++ b/lib/goon_model_gen/builder/model_builder.rb
@@ -1,5 +1,6 @@
 require "goon_model_gen"
 
+require "goon_model_gen/config"
 require "goon_model_gen/builder/abstract_builder"
 
 require "goon_model_gen/source/struct"
@@ -15,6 +16,11 @@ require "active_support/core_ext/string"
 module GoonModelGen
   module Builder
     class ModelBuilder < AbstractBuilder
+
+      # @param config [GoonModelGen::Config]
+      def initialize(config)
+        super(config, config.model_package_path)
+      end
 
       # @param package_path [String]
       # @param types [Array<Source::Type>]
@@ -46,7 +52,7 @@ module GoonModelGen
 
       # @param pkgs [Golang::Packages]
       def resolve_type_names(pkgs)
-        pkgs.resolve_type_names(Golang::DatastorePackageFactory.new.packages)
+        pkgs.resolve_type_names(Golang::DatastorePackageFactory.new(config.package_alias_map).packages)
       end
 
       # @param t [Source::Struct]

--- a/lib/goon_model_gen/builder/model_builder.rb
+++ b/lib/goon_model_gen/builder/model_builder.rb
@@ -8,7 +8,7 @@ require "goon_model_gen/source/named_slice"
 
 require "goon_model_gen/golang/package"
 require "goon_model_gen/golang/packages"
-require "goon_model_gen/golang/datastore_supported"
+require "goon_model_gen/golang/datastore_package_factory"
 
 require "active_support/core_ext/string"
 
@@ -46,7 +46,7 @@ module GoonModelGen
 
       # @param pkgs [Golang::Packages]
       def resolve_type_names(pkgs)
-        pkgs.resolve_type_names(Golang::DatastoreSupported.packages)
+        pkgs.resolve_type_names(Golang::DatastorePackageFactory.new.packages)
       end
 
       # @param t [Source::Struct]

--- a/lib/goon_model_gen/builder/store_builder.rb
+++ b/lib/goon_model_gen/builder/store_builder.rb
@@ -5,7 +5,7 @@ require "goon_model_gen/builder/abstract_builder"
 require "goon_model_gen/source/struct"
 
 require "goon_model_gen/golang/package"
-require "goon_model_gen/golang/datastore_supported"
+require "goon_model_gen/golang/datastore_package_factory"
 
 
 module GoonModelGen
@@ -44,7 +44,7 @@ module GoonModelGen
 
       # @param pkgs [Golang::Packages]
       def resolve_type_names(pkgs)
-        pkgs.resolve_type_names(Golang::DatastoreSupported.packages.dup.add(model_packages))
+        pkgs.resolve_type_names(Golang::DatastorePackageFactory.new.packages.dup.add(model_packages))
       end
 
     end

--- a/lib/goon_model_gen/builder/store_builder.rb
+++ b/lib/goon_model_gen/builder/store_builder.rb
@@ -1,5 +1,6 @@
 require "goon_model_gen"
 
+require "goon_model_gen/config"
 require "goon_model_gen/builder/abstract_builder"
 
 require "goon_model_gen/source/struct"
@@ -13,10 +14,10 @@ module GoonModelGen
     class StoreBuilder < AbstractBuilder
       attr_reader :model_packages
 
-      # @param base_package_path [String]
+      # @param config [GoonModelGen::Config]
       # @param model_packages [Golang::Packages]
-      def initialize(base_package_path, model_packages)
-        super(base_package_path)
+      def initialize(config, model_packages)
+        super(config, config.store_package_path)
         @package_suffix = "_store"
         @model_packages = model_packages
       end
@@ -44,7 +45,7 @@ module GoonModelGen
 
       # @param pkgs [Golang::Packages]
       def resolve_type_names(pkgs)
-        pkgs.resolve_type_names(Golang::DatastorePackageFactory.new.packages.dup.add(model_packages))
+        pkgs.resolve_type_names(Golang::DatastorePackageFactory.new(config.package_alias_map).packages.dup.add(model_packages))
       end
 
     end

--- a/lib/goon_model_gen/builder/validation_builder.rb
+++ b/lib/goon_model_gen/builder/validation_builder.rb
@@ -3,7 +3,7 @@ require "goon_model_gen"
 require "goon_model_gen/builder/abstract_builder"
 
 require "goon_model_gen/golang/packages"
-require "goon_model_gen/golang/datastore_supported"
+require "goon_model_gen/golang/datastore_package_factory"
 
 
 module GoonModelGen
@@ -24,7 +24,7 @@ module GoonModelGen
 
       # @param pkgs [Golang::Packages]
       def resolve_type_names(pkgs)
-        pkgs.resolve_type_names(Golang::DatastoreSupported.packages)
+        pkgs.resolve_type_names(Golang::DatastorePackageFactory.new.packages)
       end
 
     end

--- a/lib/goon_model_gen/builder/validation_builder.rb
+++ b/lib/goon_model_gen/builder/validation_builder.rb
@@ -1,5 +1,6 @@
 require "goon_model_gen"
 
+require "goon_model_gen/config"
 require "goon_model_gen/builder/abstract_builder"
 
 require "goon_model_gen/golang/packages"
@@ -9,6 +10,11 @@ require "goon_model_gen/golang/datastore_package_factory"
 module GoonModelGen
   module Builder
     class ValidationBuilder < AbstractBuilder
+
+      # @param config [GoonModelGen::Config]
+      def initialize(config)
+        super(config, config.validation_package_path)
+      end
 
       # @return [Golang::Packages]
       def build(*)
@@ -24,7 +30,7 @@ module GoonModelGen
 
       # @param pkgs [Golang::Packages]
       def resolve_type_names(pkgs)
-        pkgs.resolve_type_names(Golang::DatastorePackageFactory.new.packages)
+        pkgs.resolve_type_names(Golang::DatastorePackageFactory.new(config.package_alias_map).packages)
       end
 
     end

--- a/lib/goon_model_gen/cli.rb
+++ b/lib/goon_model_gen/cli.rb
@@ -69,7 +69,7 @@ module GoonModelGen
       packages = Golang::Packages.wrap(package_hash.values.flatten)
       converter_package = packages.find_or_new(cfg.converter_package_path)
 
-      b = Builder::ConverterBuilder.new(cfg.converter_package_path, loader, Golang::Packages.new.add(*packages))
+      b = Builder::ConverterBuilder.new(cfg, loader, Golang::Packages.new.add(*packages))
       conv_packages = b.build(paths)
 
       if options[:inspect]
@@ -97,15 +97,15 @@ module GoonModelGen
       # @return [Array<Golang::Package>]
       def build_model_objects(paths)
         context = Source::Loader.new.process(paths)
-        Builder::ModelBuilder.new(cfg.model_package_path).build(context)
+        Builder::ModelBuilder.new(cfg).build(context)
       end
 
       # @param paths [Array<String>] Source::Context
       # @return [Array<Golang::Package>]
       def build_store_packages(paths)
         context = Source::Loader.new.process(paths)
-        model_packages = Builder::ModelBuilder.new(cfg.model_package_path).build(context)
-        store_packages = Builder::StoreBuilder.new(cfg.store_package_path, model_packages).build(context)
+        model_packages = Builder::ModelBuilder.new(cfg).build(context)
+        store_packages = Builder::StoreBuilder.new(cfg, model_packages).build(context)
         return store_packages
       end
 
@@ -123,7 +123,7 @@ module GoonModelGen
 
       # @return [Golang::Package]
       def validation_packages
-        Builder::ValidationBuilder.new(cfg.validation_package_path).build
+        Builder::ValidationBuilder.new(cfg).build
       end
     end
   end

--- a/lib/goon_model_gen/cli.rb
+++ b/lib/goon_model_gen/cli.rb
@@ -65,7 +65,7 @@ module GoonModelGen
     option :inspect, type: :boolean, desc: "Don't generate any file and show package objects if given"
     def converter(*paths)
       loader = Converter::Loader.new(cfg)
-      package_hash = Golang::StructsLoader.new.process(cfg.structs_json_path) # Golang::Packages
+      package_hash = Golang::StructsLoader.new(cfg).process # Golang::Packages
       packages = Golang::Packages.wrap(package_hash.values.flatten)
       converter_package = packages.find_or_new(cfg.converter_package_path)
 

--- a/lib/goon_model_gen/config.rb
+++ b/lib/goon_model_gen/config.rb
@@ -26,6 +26,7 @@ module GoonModelGen
       structs_json_path
       validator_package_path
       version_comment
+      package_alias_map
     ].freeze
 
     attr_accessor *ATTRIBUTES
@@ -46,6 +47,7 @@ module GoonModelGen
       @structs_gen_dir ||= "./cmd/structs"
       @structs_json_path ||= "./structs.json"
       @version_comment ||= false
+      @package_alias_map = {}
       self
     end
 

--- a/lib/goon_model_gen/config.rb
+++ b/lib/goon_model_gen/config.rb
@@ -5,6 +5,7 @@ require "yaml"
 require "pathname"
 
 require "goon_model_gen/golang"
+require "goon_model_gen/package_alias_map"
 
 module GoonModelGen
   class Config
@@ -47,7 +48,9 @@ module GoonModelGen
       @structs_gen_dir ||= "./cmd/structs"
       @structs_json_path ||= "./structs.json"
       @version_comment ||= false
-      @package_alias_map = {}
+      @package_alias_map ||= {}
+      @package_alias_map = PACKAGE_ALIAS_MAP.merge(@package_alias_map)
+      @package_alias_map.default_proc = proc{|hash,key| key.to_s}
       self
     end
 

--- a/lib/goon_model_gen/generator.rb
+++ b/lib/goon_model_gen/generator.rb
@@ -15,6 +15,7 @@ module GoonModelGen
     attr_accessor :version_comment # false/true
     attr_accessor :force, :skip    # false/true
     attr_accessor :overwrite_custom_file   # false/true
+    attr_accessor :package_alias_map
 
     DEFAULT_TEMPLATES_DIR = File.expand_path('../templates', __FILE__)
 
@@ -109,7 +110,7 @@ module GoonModelGen
 
     # @param cfg [Config]
     def load_config(cfg)
-      [:gofmt_disabled, :version_comment].each do |key|
+      [:gofmt_disabled, :version_comment, :package_alias_map].each do |key|
         self.send("#{key}=", cfg.send(key))
       end
     end

--- a/lib/goon_model_gen/golang/datastore_package_factory.rb
+++ b/lib/goon_model_gen/golang/datastore_package_factory.rb
@@ -10,35 +10,35 @@ module GoonModelGen
   module Golang
     class DatastorePackageFactory
 
-        def datastore
-          @datastore ||= Package.new('google.golang.org/appengine/datastore').tap do |pkg|
-            pkg.add(DatastoreSupported.new('ByteString'))
-            pkg.add(DatastoreSupported.new('Key'))
-          end
+      def datastore
+        @datastore ||= Package.new('google.golang.org/appengine/datastore').tap do |pkg|
+          pkg.add(DatastoreSupported.new('ByteString'))
+          pkg.add(DatastoreSupported.new('Key'))
         end
+      end
 
-        def time
-          @time ||= Package.new('time').tap do |pkg|
-            pkg.add(DatastoreSupported.new('Time'))
-          end
+      def time
+        @time ||= Package.new('time').tap do |pkg|
+          pkg.add(DatastoreSupported.new('Time'))
         end
+      end
 
-        def appengine
-          @appengine ||= Package.new('google.golang.org/appengine').tap do |pkg|
-            pkg.add(DatastoreSupported.new('BlobKey'))
-            pkg.add(DatastoreSupported.new('GeoPoint'))
-          end
+      def appengine
+        @appengine ||= Package.new('google.golang.org/appengine').tap do |pkg|
+          pkg.add(DatastoreSupported.new('BlobKey'))
+          pkg.add(DatastoreSupported.new('GeoPoint'))
         end
+      end
 
 
-        def packages
-          @packages ||= Packages.new.tap do |pkgs|
-            pkgs << Builtin.package
-            pkgs << datastore
-            pkgs << time
-            pkgs << appengine
-          end
+      def packages
+        @packages ||= Packages.new.tap do |pkgs|
+          pkgs << Builtin.package
+          pkgs << datastore
+          pkgs << time
+          pkgs << appengine
         end
+      end
 
     end
   end

--- a/lib/goon_model_gen/golang/datastore_package_factory.rb
+++ b/lib/goon_model_gen/golang/datastore_package_factory.rb
@@ -1,0 +1,45 @@
+require "goon_model_gen"
+
+require "goon_model_gen/golang/predeclared_type"
+require "goon_model_gen/golang/datastore_supported"
+require "goon_model_gen/golang/package"
+require "goon_model_gen/golang/packages"
+require "goon_model_gen/golang/builtin"
+
+module GoonModelGen
+  module Golang
+    class DatastorePackageFactory
+
+        def datastore
+          @datastore ||= Package.new('google.golang.org/appengine/datastore').tap do |pkg|
+            pkg.add(DatastoreSupported.new('ByteString'))
+            pkg.add(DatastoreSupported.new('Key'))
+          end
+        end
+
+        def time
+          @time ||= Package.new('time').tap do |pkg|
+            pkg.add(DatastoreSupported.new('Time'))
+          end
+        end
+
+        def appengine
+          @appengine ||= Package.new('google.golang.org/appengine').tap do |pkg|
+            pkg.add(DatastoreSupported.new('BlobKey'))
+            pkg.add(DatastoreSupported.new('GeoPoint'))
+          end
+        end
+
+
+        def packages
+          @packages ||= Packages.new.tap do |pkgs|
+            pkgs << Builtin.package
+            pkgs << datastore
+            pkgs << time
+            pkgs << appengine
+          end
+        end
+
+    end
+  end
+end

--- a/lib/goon_model_gen/golang/datastore_package_factory.rb
+++ b/lib/goon_model_gen/golang/datastore_package_factory.rb
@@ -9,9 +9,13 @@ require "goon_model_gen/golang/builtin"
 module GoonModelGen
   module Golang
     class DatastorePackageFactory
+      attr_reader :package_alias_map
+      def initialize(package_alias_map)
+        @package_alias_map = package_alias_map
+      end
 
       def datastore
-        @datastore ||= Package.new('google.golang.org/appengine/datastore').tap do |pkg|
+        @datastore ||= Package.new(package_alias_map['datastore']).tap do |pkg|
           pkg.add(DatastoreSupported.new('ByteString'))
           pkg.add(DatastoreSupported.new('Key'))
         end
@@ -24,7 +28,7 @@ module GoonModelGen
       end
 
       def appengine
-        @appengine ||= Package.new('google.golang.org/appengine').tap do |pkg|
+        @appengine ||= Package.new(package_alias_map['appengine']).tap do |pkg|
           pkg.add(DatastoreSupported.new('BlobKey'))
           pkg.add(DatastoreSupported.new('GeoPoint'))
         end

--- a/lib/goon_model_gen/golang/datastore_supported.rb
+++ b/lib/goon_model_gen/golang/datastore_supported.rb
@@ -1,48 +1,10 @@
 require "goon_model_gen"
 
 require "goon_model_gen/golang/predeclared_type"
-require "goon_model_gen/golang/package"
-require "goon_model_gen/golang/packages"
-require "goon_model_gen/golang/builtin"
 
 module GoonModelGen
   module Golang
     class DatastoreSupported < PredeclaredType
-
-      class << self
-
-        def datastore
-          @datastore ||= Package.new('google.golang.org/appengine/datastore').tap do |pkg|
-            pkg.add(self.new('ByteString'))
-            pkg.add(self.new('Key'))
-          end
-        end
-
-        def time
-          @time ||= Package.new('time').tap do |pkg|
-            pkg.add(self.new('Time'))
-          end
-        end
-
-        def appengine
-          @appengine ||= Package.new('google.golang.org/appengine').tap do |pkg|
-            pkg.add(self.new('BlobKey'))
-            pkg.add(self.new('GeoPoint'))
-          end
-        end
-
-
-        def packages
-          @packages ||= Packages.new.tap do |pkgs|
-            pkgs << Builtin.package
-            pkgs << datastore
-            pkgs << time
-            pkgs << appengine
-          end
-        end
-
-      end
-
     end
   end
 end

--- a/lib/goon_model_gen/golang/structs_loader.rb
+++ b/lib/goon_model_gen/golang/structs_loader.rb
@@ -4,7 +4,7 @@ require "erb"
 require "yaml"
 
 require "goon_model_gen/golang/packages"
-require "goon_model_gen/golang/datastore_supported"
+require "goon_model_gen/golang/datastore_package_factory"
 
 require "active_support/core_ext/string"
 
@@ -24,7 +24,7 @@ module GoonModelGen
           d[key] = build_packages(types)
         end
 
-        whole_packages = Golang::DatastoreSupported.packages.dup
+        whole_packages = Golang::DatastorePackageFactory.new.packages.dup
         r.values.each do |pkgs|
           whole_packages.add(*pkgs)
         end

--- a/lib/goon_model_gen/golang/structs_loader.rb
+++ b/lib/goon_model_gen/golang/structs_loader.rb
@@ -3,6 +3,7 @@ require "goon_model_gen"
 require "erb"
 require "yaml"
 
+require "goon_model_gen/config"
 require "goon_model_gen/golang/packages"
 require "goon_model_gen/golang/datastore_package_factory"
 
@@ -12,9 +13,15 @@ module GoonModelGen
   module Golang
     class StructsLoader
 
-      # @param path [String]
+      # @param cnoofig [GoonModelGen::Config]
+      def initialize(config)
+        @config = config
+      end
+
       # @return [Hash<String,Packages>]
-      def process(path)
+      def process
+        path = config.structs_json_path
+
         erb = ERB.new(::File.read(path), nil, "-")
         erb.filename = path
         txt = erb.result
@@ -24,7 +31,7 @@ module GoonModelGen
           d[key] = build_packages(types)
         end
 
-        whole_packages = Golang::DatastorePackageFactory.new.packages.dup
+        whole_packages = Golang::DatastorePackageFactory.new(config.package_alias_map).packages.dup
         r.values.each do |pkgs|
           whole_packages.add(*pkgs)
         end

--- a/lib/goon_model_gen/package_alias_map.rb
+++ b/lib/goon_model_gen/package_alias_map.rb
@@ -1,0 +1,16 @@
+require "goon_model_gen"
+
+require "erb"
+require "yaml"
+require "pathname"
+
+require "goon_model_gen/golang"
+
+module GoonModelGen
+  PACKAGE_ALIAS_MAP = {
+    'appengine' => 'google.golang.org/appengine',
+    'datastore' => 'google.golang.org/appengine/datastore',
+    'log'       => 'google.golang.org/appengine/log',
+    'goon'      => 'github.com/mjibson/goon',
+  }
+end

--- a/lib/goon_model_gen/templates/dsl.rb
+++ b/lib/goon_model_gen/templates/dsl.rb
@@ -13,6 +13,7 @@ module GoonModelGen
         package_path = package_or_nil || alias_or_package
         new_alias = package_or_nil ? alias_or_package.to_s : nil
         package_path = package_path.path if package_path.respond_to?(:path)
+        package_path = package_alias_map[package_path]
         return if package_path.blank?
         if dependencies.key?(package_path)
           old_alias = dependencies[package_path]

--- a/lib/goon_model_gen/templates/store/goon/01_Binder.go.erb
+++ b/lib/goon_model_gen/templates/store/goon/01_Binder.go.erb
@@ -1,5 +1,5 @@
 <%-
-import 'google.golang.org/appengine/datastore'
+import 'datastore'
 import model.package
 -%>
 

--- a/lib/goon_model_gen/templates/store/goon/05_Query.go.erb
+++ b/lib/goon_model_gen/templates/store/goon/05_Query.go.erb
@@ -1,5 +1,5 @@
 <%-
-import 'google.golang.org/appengine/datastore'
+import 'datastore'
 -%>
 
 func (s *<%= type.name %>) Query() *datastore.Query {

--- a/lib/goon_model_gen/templates/store/goon/06_Run.go.erb
+++ b/lib/goon_model_gen/templates/store/goon/06_Run.go.erb
@@ -1,7 +1,7 @@
 <%-
 import 'context'
-import 'google.golang.org/appengine/datastore'
-import 'github.com/mjibson/goon'
+import 'datastore'
+import 'goon'
 -%>
 
 func (s *<%= type.name %>) Run(ctx context.Context, q *datastore.Query) *goon.Iterator {

--- a/lib/goon_model_gen/templates/store/goon/08_AllBy.go.erb
+++ b/lib/goon_model_gen/templates/store/goon/08_AllBy.go.erb
@@ -1,8 +1,8 @@
 <%-
 import 'context'
 import model.package
-import 'google.golang.org/appengine/datastore'
-import 'google.golang.org/appengine/log'
+import 'datastore'
+import 'log'
 -%>
 
 func (s *<%= type.name %>) AllBy(ctx context.Context, q *datastore.Query) ([]*<%= model.qualified_name %>, error) {

--- a/lib/goon_model_gen/templates/store/goon/09_Select.go.erb
+++ b/lib/goon_model_gen/templates/store/goon/09_Select.go.erb
@@ -1,7 +1,7 @@
 <%-
 import 'context'
 import model.package
-import 'google.golang.org/appengine/datastore'
+import 'datastore'
 -%>
 
 func (s *<%= type.name %>) Select(ctx context.Context, q *datastore.Query) ([]*<%= model.qualified_name %>, error) {

--- a/lib/goon_model_gen/templates/store/goon/10_FirstBy.go.erb
+++ b/lib/goon_model_gen/templates/store/goon/10_FirstBy.go.erb
@@ -1,7 +1,7 @@
 <%-
 import 'context'
 import model.package
-import 'google.golang.org/appengine/datastore'
+import 'datastore'
 -%>
 
 func (s *<%= type.name %>) FirstBy(ctx context.Context, q *datastore.Query) (*<%= model.qualified_name %>, error) {

--- a/lib/goon_model_gen/templates/store/goon/11_CountBy.go.erb
+++ b/lib/goon_model_gen/templates/store/goon/11_CountBy.go.erb
@@ -1,8 +1,8 @@
 <%-
 import 'context'
-import 'google.golang.org/appengine/datastore'
-import 'google.golang.org/appengine/log'
-import 'github.com/mjibson/goon'
+import 'datastore'
+import 'log'
+import 'goon'
 -%>
 
 func (s *<%= type.name %>) CountBy(ctx context.Context, q *datastore.Query) (int, error) {

--- a/lib/goon_model_gen/templates/store/goon/13_ByKey.go.erb
+++ b/lib/goon_model_gen/templates/store/goon/13_ByKey.go.erb
@@ -1,8 +1,8 @@
 <%-
 import 'context'
 import model.package
-import 'google.golang.org/appengine/datastore'
-import 'google.golang.org/appengine/log'
+import 'datastore'
+import 'log'
 -%>
 
 func (s *<%= type.name %>) ByKey(ctx context.Context, key *datastore.Key) (*<%= model.qualified_name %>, error) {

--- a/lib/goon_model_gen/templates/store/goon/14_Get.go.erb
+++ b/lib/goon_model_gen/templates/store/goon/14_Get.go.erb
@@ -1,9 +1,9 @@
 <%-
 import 'context'
 import model.package
-import 'google.golang.org/appengine/datastore'
-import 'google.golang.org/appengine/log'
-import 'github.com/mjibson/goon'
+import 'datastore'
+import 'log'
+import 'goon'
 -%>
 
 func (s *<%= type.name %>) Get(ctx context.Context, m *<%= model.qualified_name %>) error {

--- a/lib/goon_model_gen/templates/store/goon/15_IsValidKey.go.erb
+++ b/lib/goon_model_gen/templates/store/goon/15_IsValidKey.go.erb
@@ -2,9 +2,9 @@
 import 'context'
 import 'fmt'
 import model.package
-import 'google.golang.org/appengine/datastore'
-import 'google.golang.org/appengine/log'
-import 'github.com/mjibson/goon'
+import 'datastore'
+import 'log'
+import 'goon'
 -%>
 
 func (s *<%= type.name %>) IsValidKey(ctx context.Context, key *datastore.Key) error {

--- a/lib/goon_model_gen/templates/store/goon/16_Exist.go.erb
+++ b/lib/goon_model_gen/templates/store/goon/16_Exist.go.erb
@@ -1,9 +1,9 @@
 <%-
 import 'context'
 import model.package
-import 'google.golang.org/appengine/datastore'
-import 'google.golang.org/appengine/log'
-import 'github.com/mjibson/goon'
+import 'datastore'
+import 'log'
+import 'goon'
 -%>
 
 func (s *<%= type.name %>) Exist(ctx context.Context, m *<%= model.qualified_name %>) (bool, error) {

--- a/lib/goon_model_gen/templates/store/goon/17_Save.go.erb
+++ b/lib/goon_model_gen/templates/store/goon/17_Save.go.erb
@@ -1,7 +1,7 @@
 <%-
 import 'context'
 import model.package
-import 'google.golang.org/appengine/datastore'
+import 'datastore'
 -%>
 
 func (s *<%= type.name %>) Save(ctx context.Context, m *<%= model.qualified_name %>) (*datastore.Key, error) {

--- a/lib/goon_model_gen/templates/store/goon/18_Create.go.erb
+++ b/lib/goon_model_gen/templates/store/goon/18_Create.go.erb
@@ -2,8 +2,8 @@
 import 'context'
 import 'fmt'
 import model.package
-import 'google.golang.org/appengine/datastore'
-import 'google.golang.org/appengine/log'
+import 'datastore'
+import 'log'
 -%>
 
 func (s *<%= type.name %>) Create(ctx context.Context, m *<%= model.qualified_name %>) (*datastore.Key, error) {

--- a/lib/goon_model_gen/templates/store/goon/19_Update.go.erb
+++ b/lib/goon_model_gen/templates/store/goon/19_Update.go.erb
@@ -2,8 +2,8 @@
 import 'context'
 import 'fmt'
 import model.package
-import 'google.golang.org/appengine/datastore'
-import 'google.golang.org/appengine/log'
+import 'datastore'
+import 'log'
 -%>
 
 func (s *<%= type.name %>) Update(ctx context.Context, m *<%= model.qualified_name %>) (*datastore.Key, error) {

--- a/lib/goon_model_gen/templates/store/goon/20_PutWith.go.erb
+++ b/lib/goon_model_gen/templates/store/goon/20_PutWith.go.erb
@@ -1,7 +1,7 @@
 <%-
 import 'context'
 import model.package
-import 'google.golang.org/appengine/datastore'
+import 'datastore'
 -%>
 
 func (s *<%= type.name %>) PutWith(ctx context.Context, m *<%= model.qualified_name %>, f func() error) (*datastore.Key, error) {

--- a/lib/goon_model_gen/templates/store/goon/21_Put.go.erb
+++ b/lib/goon_model_gen/templates/store/goon/21_Put.go.erb
@@ -1,9 +1,9 @@
 <%-
 import 'context'
 import model.package
-import 'google.golang.org/appengine/datastore'
-import 'google.golang.org/appengine/log'
-import 'github.com/mjibson/goon'
+import 'datastore'
+import 'log'
+import 'goon'
 -%>
 
 func (s *<%= type.name %>) Put(ctx context.Context, m *<%= model.qualified_name %>) (*datastore.Key, error) {

--- a/lib/goon_model_gen/templates/store/goon/22_Delete.go.erb
+++ b/lib/goon_model_gen/templates/store/goon/22_Delete.go.erb
@@ -1,8 +1,8 @@
 <%-
 import 'context'
 import model.package
-import 'google.golang.org/appengine/log'
-import 'github.com/mjibson/goon'
+import 'log'
+import 'goon'
 -%>
 
 func (s *<%= type.name %>) Delete(ctx context.Context, m *<%= model.qualified_name %>) error {

--- a/lib/goon_model_gen/version.rb
+++ b/lib/goon_model_gen/version.rb
@@ -1,3 +1,3 @@
 module GoonModelGen
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end

--- a/spec/goon_model_gen/golang/datastore_supported_spec.rb
+++ b/spec/goon_model_gen/golang/datastore_supported_spec.rb
@@ -1,8 +1,8 @@
-require "goon_model_gen/golang/datastore_supported"
+require "goon_model_gen/golang/datastore_package_factory"
 
-RSpec.describe GoonModelGen::Golang::DatastoreSupported do
+RSpec.describe GoonModelGen::Golang::DatastorePackageFactory do
   context :packages do
-    subject{ GoonModelGen::Golang::DatastoreSupported.packages }
+    subject{ GoonModelGen::Golang::DatastorePackageFactory.new.packages }
 
     it "can find appengine.GeoPoint" do
       t = subject.type_for("appengine.GeoPoint")

--- a/spec/goon_model_gen/golang/datastore_supported_spec.rb
+++ b/spec/goon_model_gen/golang/datastore_supported_spec.rb
@@ -1,8 +1,10 @@
 require "goon_model_gen/golang/datastore_package_factory"
 
+require "goon_model_gen/package_alias_map"
+
 RSpec.describe GoonModelGen::Golang::DatastorePackageFactory do
   context :packages do
-    subject{ GoonModelGen::Golang::DatastorePackageFactory.new.packages }
+    subject{ GoonModelGen::Golang::DatastorePackageFactory.new(GoonModelGen::PACKAGE_ALIAS_MAP).packages }
 
     it "can find appengine.GeoPoint" do
       t = subject.type_for("appengine.GeoPoint")


### PR DESCRIPTION
For example, you can replace `google.golang.org/appengine/log` to another package by using package_path_map in config file.